### PR TITLE
fix a typo in the readme; playbooks are located at setup/, not public/

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ config::
 
 Which would be reachable at::
 
-    public/slave/
+    setup/slave/
 
 And all query args would be passed onto the template file.
 


### PR DESCRIPTION
Signed-off-by: Andrew Schoen aschoen@redhat.com
