### PR TITLE
prompt for the local path to the jenkins_build private key

### DIFF
--- a/deploy/playbooks/deploy.yml
+++ b/deploy/playbooks/deploy.yml
@@ -9,3 +9,8 @@
      use_ssl: true
      wsgi_file: wsgi.py
      wsgi_callable: application
+  vars_prompt:
+     - name: "jenkins_build_private_key_path"
+       prompt: "Enter the path to the jenkins_build private ssh key. If not provided this step will be skipped."
+       default: false
+       private: no

--- a/deploy/playbooks/roles/common/tasks/main.yml
+++ b/deploy/playbooks/roles/common/tasks/main.yml
@@ -37,6 +37,12 @@
     version: master
     update: yes
 
+- name: upload the jenkins_build ssh private key
+  template:
+    src: "{{ jenkins_build_private_key_path }}"
+    dest: "{{ app_home }}/src/{{ app_name }}/public/ceph-build/ansible/files/ssh/keys/jenkins_build"
+  when: jenkins_build_private_key_path
+
 - name: install python requirements in virtualenv
   pip:
     requirements: "{{ app_home }}/src/{{ app_name }}/requirements.txt"


### PR DESCRIPTION
We might not want to do this, but it's a way to make sure we don't forget to deploy this file and not include it in ceph-build or prado. It's optional so we'll only have to provide the path on the first deploy to a new environment.

If we wanted we could store the key in a private github repo or something.
