### PR TITLE
ansible: explicitly set selinux to "permissive"

### DIFF
--- a/deploy/playbooks/roles/common/tasks/main.yml
+++ b/deploy/playbooks/roles/common/tasks/main.yml
@@ -46,4 +46,10 @@
 
 - include: circus.yml
 
+# nginx sets an selinux boolean setting, which requires that selinux be
+# "enforcing" or "permissive", not "disabled".
+- name: set selinux to permissive
+  selinux:
+    state: permissive
+
 - include: nginx.yml


### PR DESCRIPTION
In OVH's cloud images for CentOS 7, SELinux is disabled. This causes nginx.yml's seboolean setting to fail.

Ensure that we're in permissive mode so that the seboolean setting in nginx.yml will succeed.
