### PR TITLE
ansible: set explict selinux policy

### DIFF
--- a/deploy/playbooks/roles/common/tasks/main.yml
+++ b/deploy/playbooks/roles/common/tasks/main.yml
@@ -69,6 +69,7 @@
 # "enforcing" or "permissive", not "disabled".
 - name: set selinux to permissive
   selinux:
+    policy: targeted
     state: permissive
 
 - include: nginx.yml


### PR DESCRIPTION
From http://docs.ansible.com/ansible/selinux_module.html:
The policy setting "will be required if state is not 'disabled'"

This fixes an error during deployment:

```
failed: [prado.ceph.com] => {"failed": true}
msg: policy is required if state is not 'disabled'
```
