### PR TITLE
fix prod_api_creds import

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 from prado.hooks import error
-from prod_api_creds import api_key, api_user
+from configs.prod_api_creds import api_key, api_user
 
 # Server Specific Configurations
 server = {


### PR DESCRIPTION
Prior to this change, `gunicorn_pecan` would fail to start up, with the following error:

```
Error: No module named prod_api_creds
```

Pecan's `prod.py` config could not load `prod_api_creds.py` from the same directory.
