### PR TITLE
Use --extra-vars instead of using Mako templating on the playbook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,8 +53,8 @@ config::
 
     build_map = {
         "slave": {
-            "playbook": "%(confdir)s/public/ceph-build/ansible/slaves",
-            "template": "%(confdir)s/public/ceph-build/ansible/slaves/slave.yml.j2",
+            "playbook_path": "%(confdir)s/public/ceph-build/ansible/slaves",
+            "playbook": "%(confdir)s/public/ceph-build/ansible/slaves/slave.yml",
             "command": 'ansible-playbook -i "localhost," -c local ../main.yml'
         }
     }
@@ -64,24 +64,6 @@ Which would be reachable at::
     setup/slave/
 
 and all HTTP query args would be passed onto the template file.
-
-templating
-----------
-To avoid collision with Ansible's support for Jinja2, templates for playbooks
-use Mako (http://www.makotemplates.org/).
-
-A simple debug message in a playbook template that looks like::
-
-    - debug: msg="this is a message where ${foo} and ${meh} should be defined"
-
-would get rendered and ready to execute when passing the variables to the
-configured endpoint (using 'slave' here as an example)::
-
-    http://0.0.0.0:8000/setup/slave/?foo=1&meh=2
-
-Output of the playbook would show::
-
-    TASK: [debug msg="this is a message where 1 and 2 should be defined"] *******
 
 command
 -------

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ what a host needs when executing.
 
 An example call to the webservice by the host would look like::
 
-    curl -L http://prado.example/setup/myplaybook/ | bash
+    curl -u api_user:api_key -L "http://prado.example/setup/myplaybook/?foo=bar&bar=baz" | bash
 
 project name
 ------------

--- a/deploy/playbooks/deploy.yml
+++ b/deploy/playbooks/deploy.yml
@@ -6,6 +6,7 @@
     - common
   vars:
      app_name: "prado"
+     branch: "master"
      use_ssl: true
      wsgi_file: wsgi.py
      wsgi_callable: application

--- a/deploy/playbooks/deploy_vagrant.yml
+++ b/deploy/playbooks/deploy_vagrant.yml
@@ -1,0 +1,12 @@
+---
+
+- hosts: all
+  user: vagrant 
+  roles:
+    - common
+  vars:
+     app_name: "prado"
+     branch: "master"
+     use_ssl: true
+     wsgi_file: wsgi.py
+     wsgi_callable: application

--- a/deploy/playbooks/roles/common/tasks/main.yml
+++ b/deploy/playbooks/roles/common/tasks/main.yml
@@ -24,7 +24,7 @@
   pip: name=pip virtualenv={{ app_home }} extra_args='--upgrade'
 
 - name: pip+git install {{ app_name }} into virtualenv.
-  pip: name='git+https://github.com/alfredodeza/{{ app_name }}#egg={{ app_name }}' virtualenv={{ app_home }}
+  pip: name='git+https://github.com/alfredodeza/{{ app_name }}@{{ branch }}#egg={{ app_name }}' virtualenv={{ app_home }}
   changed_when: False
 
 # this will only be used if the credentials where not passed in explicitly over

--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -51,8 +51,8 @@ delegate_downloads = False
 
 build_map = {
     "slave": {
-        "playbook": "%(confdir)s/../public/ceph-build/ansible",
-        "template": "%(confdir)s/../public/ceph-build/ansible/slave.yml.j2",
+        "playbook_path": "%(confdir)s/../public/ceph-build/ansible",
+        "playbook": "%(confdir)s/../public/ceph-build/ansible/slave.yml.j2",
         "command": 'ansible-playbook -i "localhost," -c local ../main.yml'
     }
 }

--- a/prado/controllers/build.py
+++ b/prado/controllers/build.py
@@ -1,5 +1,8 @@
 import os
 import tempfile
+
+from shutil import copyfile
+
 from pecan import expose, response, conf, abort
 from pecan.secure import secure
 from webob.static import FileIter
@@ -20,16 +23,14 @@ class BuildController(object):
         except (AttributeError, KeyError):
             abort(404)
 
-        template = conf.build_map[self.name]['template']
         playbook = conf.build_map[self.name]['playbook']
+        playbook_path = conf.build_map[self.name]['playbook_path']
 
         files_to_compress = []
-        rendered_yml = render(template, **kw)
         tmp_dir = tempfile.mkdtemp()
         yml_file = os.path.join(tmp_dir, 'main.yml')
-        with open(yml_file, 'w') as f:
-            f.write(rendered_yml)
-        files_to_compress.append(playbook)
+        copyfile(playbook, yml_file)
+        files_to_compress.append(playbook_path)
         files_to_compress.append(yml_file)
 
         playbook = tar_czf(files_to_compress)

--- a/prado/util.py
+++ b/prado/util.py
@@ -1,4 +1,5 @@
 import os
+import json
 from urllib import urlencode
 from StringIO import StringIO
 import tempfile
@@ -41,9 +42,7 @@ def make_setup_script(name, **params):
     command = conf.build_map[name]['command']
     address = conf.service_address.strip('/')
     if params:
-        encoded = "?%s" % urlencode(params)
-    else:
-        encoded = ""
+        command = "{} --extra-vars {}".format(command, json.dumps(params))
     bash = """#!/bin/bash -x -e
 # Do not use sudo for any commands as this script is ran
 # by root.
@@ -52,7 +51,7 @@ echo "--> do not requiretty for sudoers"
 sed -i "s/Defaults    requiretty/#Defaults    requiretty/" /etc/sudoers
 
 echo "--> getting ready to fetch ansible"
-build_tar="{address}/build/{name}{encoded}"
+build_tar="{address}/build/{name}"
 ansible_tar="{address}/setup/ansible/"
 
 # Define and create a temporary directory for this build
@@ -79,7 +78,6 @@ ANSIBLE_LIBRARY=$ANSIBLE_LIBRARY:$library bash ../build/bin/{command}
             address=address,
             command=command,
             name=name,
-            encoded=encoded,
             user=conf.api_user,
             key=conf.api_key,
         )

--- a/prado/util.py
+++ b/prado/util.py
@@ -42,7 +42,7 @@ def make_setup_script(name, **params):
     command = conf.build_map[name]['command']
     address = conf.service_address.strip('/')
     if params:
-        command = "{} --extra-vars {}".format(command, json.dumps(params))
+        command = "{} --extra-vars '{}'".format(command, json.dumps(params))
     bash = """#!/bin/bash -x -e
 # Do not use sudo for any commands as this script is ran
 # by root.


### PR DESCRIPTION
We don't need to use extra templating here, we can use regular jinja2 variables in the playbooks and then just use --extra-vars when we call ansible to provide those values.
